### PR TITLE
add cta-layout style

### DIFF
--- a/configs/styles/cta-layout.js
+++ b/configs/styles/cta-layout.js
@@ -1,15 +1,16 @@
-const {cx, Version, bsiProperty} = require('@bsi-cx/design-build');
+const { cx, Version, bsiProperty } = require('@bsi-cx/design-build');
 
 const backgroundColor = bsiProperty('buttonBackgroundColor', '#2F4E66');
 const borderColor = bsiProperty('buttonBorderColor', '#2F4E66');
 const borderSize = bsiProperty('buttonBorderSize', 2).value;
 const horizontalPadding = bsiProperty('buttonHorizontalPadding', 30).value;
-const verticalPadding = bsiProperty ('buttonVerticalPadding', 10).value;
-const borderFilled = (backgroundColor.hex == borderColor.hex) ? 'border: ' + '0' +';' : '';
+const verticalPadding = bsiProperty('buttonVerticalPadding', 10).value;
+const borderAndBackgroundSame = backgroundColor.hex === borderColor.hex;
+const borderFilled = borderAndBackgroundSame ? 'border: 0;' : '';
 //if border color and background color are different a border is already set and not necessary
-const borderOutline = (backgroundColor.hex != borderColor.hex) ? '' : 'border: ' + borderSize + 'px ' + 'solid ' + borderColor +';';
-const paddingFilled = (backgroundColor.hex == borderColor.hex) ? 'padding:' + (verticalPadding+borderSize) + 'px ' + (horizontalPadding+borderSize) + 'px' +';' : '';
-const paddingOutline = (backgroundColor.hex == borderColor.hex) ? 'padding:' + verticalPadding + 'px ' + horizontalPadding + 'px' +';' : '';
+const borderOutline = borderAndBackgroundSame ? `border: ${borderSize}px solid ${borderColor};` : '';
+const paddingFilled = borderAndBackgroundSame ? `padding: ${(verticalPadding + borderSize)}px ${(horizontalPadding + borderSize)}px;` : '';
+const paddingOutline = borderAndBackgroundSame ? `padding: ${verticalPadding}px ${horizontalPadding}px;` : '';
 
 module.exports = cx.style
     .withIdentifier('cta-layout-b2fd9420')
@@ -25,29 +26,25 @@ module.exports = cx.style
                 cx.domManipulation
                     .withSelector('.bsi-cta-wrapper td')
                     .withAttribute('style')
-                    .withValue( 
-                        'background-color: ' + backgroundColor +';'+
-                        borderFilled),
+                    .withValue(`background-color: ${backgroundColor}; ${borderFilled}`),
                 cx.domManipulation
                     .withSelector('.bsi-cta')
                     .withAttribute('style')
                     .withValue(
-                        'color: ' + '#ffffff' +';' +
+                        'color: #ffffff;' +
                         paddingFilled)),
         cx.styleOption
-            .withStyleId('bsi-btn-outline')    
+            .withStyleId('bsi-btn-outline')
             /*.withLabel('colored, framed')*/
             .withLabel('Farbig umrandet')
             .withDomManipulations(
                 cx.domManipulation
                     .withSelector('.bsi-cta-wrapper td')
                     .withAttribute('style')
-                    .withValue( 
-                        'background-color: ' + 'transparent' +';'+ 
+                    .withValue(
+                        'background-color: transparent;' +
                         borderOutline),
                 cx.domManipulation
                     .withSelector('.bsi-cta')
                     .withAttribute('style')
-                    .withValue(
-                        'color: ' + backgroundColor +';' + 
-                        paddingOutline)));
+                    .withValue(`color: ${backgroundColor}; ${paddingOutline}`)));

--- a/configs/styles/cta-layout.js
+++ b/configs/styles/cta-layout.js
@@ -1,0 +1,53 @@
+const {cx, Version, bsiProperty} = require('@bsi-cx/design-build');
+
+const backgroundColor = bsiProperty('buttonBackgroundColor', '#2F4E66');
+const borderColor = bsiProperty('buttonBorderColor', '#2F4E66');
+const borderSize = bsiProperty('buttonBorderSize', 2).value;
+const horizontalPadding = bsiProperty('buttonHorizontalPadding', 30).value;
+const verticalPadding = bsiProperty ('buttonVerticalPadding', 10).value;
+const borderFilled = (backgroundColor.hex == borderColor.hex) ? 'border: ' + '0' +';' : '';
+//if border color and background color are different a border is already set and not necessary
+const borderOutline = (backgroundColor.hex != borderColor.hex) ? '' : 'border: ' + borderSize + 'px ' + 'solid ' + borderColor +';';
+const paddingFilled = (backgroundColor.hex == borderColor.hex) ? 'padding:' + (verticalPadding+borderSize) + 'px ' + (horizontalPadding+borderSize) + 'px' +';' : '';
+const paddingOutline = (backgroundColor.hex == borderColor.hex) ? 'padding:' + verticalPadding + 'px ' + horizontalPadding + 'px' +';' : '';
+
+module.exports = cx.style
+    .withIdentifier('cta-layout-b2fd9420')
+    .withMinVersion(Version.CX_23_2)
+    /*.withLabel('Button layout')*/
+    .withLabel('Button Layout')
+    .withStyleOptions(
+        cx.styleOption
+            .withStyleId('bsi-btn-filled')
+            /*.withLabel('colored, filled')*/
+            .withLabel('Farbig ausgefüllt')
+            .withDomManipulations(
+                cx.domManipulation
+                    .withSelector('.bsi-cta-wrapper td')
+                    .withAttribute('style')
+                    .withValue( 
+                        'background-color: ' + backgroundColor +';'+
+                        borderFilled),
+                cx.domManipulation
+                    .withSelector('.bsi-cta')
+                    .withAttribute('style')
+                    .withValue(
+                        'color: ' + '#ffffff' +';' +
+                        paddingFilled)),
+        cx.styleOption
+            .withStyleId('bsi-btn-outline')    
+            /*.withLabel('colored, framed')*/
+            .withLabel('Farbig umrandet')
+            .withDomManipulations(
+                cx.domManipulation
+                    .withSelector('.bsi-cta-wrapper td')
+                    .withAttribute('style')
+                    .withValue( 
+                        'background-color: ' + 'transparent' +';'+ 
+                        borderOutline),
+                cx.domManipulation
+                    .withSelector('.bsi-cta')
+                    .withAttribute('style')
+                    .withValue(
+                        'color: ' + backgroundColor +';' + 
+                        paddingOutline)));

--- a/content-elements/base/cta/prototype/index.js
+++ b/content-elements/base/cta/prototype/index.js
@@ -26,7 +26,9 @@ module.exports = (
   .withLabel(elementLabel)
   .withDescription(elementDescription)
   .withIcon(Icon.MEGAPHONE)
-  .withStyleConfigs(require('../../../../configs/styles/cta-alignment'))
+  .withStyleConfigs(
+    require('../../../../configs/styles/cta-alignment'),
+    require('../../../../configs/styles/cta-layout'))
   .withParts(
     cx.part.link
       .withId(elementPartId)

--- a/content-elements/base/cta/prototype/template.twig
+++ b/content-elements/base/cta/prototype/template.twig
@@ -24,7 +24,7 @@
         {% set ctaVerticalPadding = ctaVerticalPadding + ctaBorderSize %}
     {% endif %}   
     {% set ctaFullWidth = (fullWidth ?: properties.buttonFullWidth) ?: false %} {# if you set this to true, your buttons will span the full width #}
-    {% set ctaFullWidthStyle = ctaFullWidth == true ? 'width="100%"' : '' %}
+    {% set ctaFullWidthStyle = ctaFullWidth ? 'width="100%"' : '' %}
     {% set borderCss = borderAndBackgroundSame ? "border:0 ;" : "border: #{ctaBorderSize}px solid #{ctaBorderColor};" %}
     {% set borderCssOutlook = borderAndBackgroundSame ? "" : "mso-border-alt: #{ctaBorderSize}px solid #{ctaBorderColor};" %}
     {% set ctaLegacyVmlMode = (legacyVml ?: properties.buttonLegacyVml) ?: false %} {# if you set this to true, your buttons will have rounded corners in Outlook as well. The button will have a fixed width though instad of fitting its size to the actual content #}

--- a/content-elements/base/cta/prototype/template.twig
+++ b/content-elements/base/cta/prototype/template.twig
@@ -25,7 +25,7 @@
     {% endif %}   
     {% set ctaFullWidth = (fullWidth ?: properties.buttonFullWidth) ?: false %} {# if you set this to true, your buttons will span the full width #}
     {% set ctaFullWidthStyle = ctaFullWidth == true ? 'width="100%"' : '' %}
-    {% set borderCss = borderAndBackgroundSame ? "" : "border: #{ctaBorderSize}px solid #{ctaBorderColor};" %}
+    {% set borderCss = borderAndBackgroundSame ? "border:0 ;" : "border: #{ctaBorderSize}px solid #{ctaBorderColor};" %}
     {% set borderCssOutlook = borderAndBackgroundSame ? "" : "mso-border-alt: #{ctaBorderSize}px solid #{ctaBorderColor};" %}
     {% set ctaLegacyVmlMode = (legacyVml ?: properties.buttonLegacyVml) ?: false %} {# if you set this to true, your buttons will have rounded corners in Outlook as well. The button will have a fixed width though instad of fitting its size to the actual content #}
     

--- a/content-elements/base/cta/prototype/template.twig
+++ b/content-elements/base/cta/prototype/template.twig
@@ -65,13 +65,13 @@
                     <td>
                         <table align="{{ ctaAlignment }}" class="bsi-cta-wrapper cta-alignment" role="presentation" border="0" cellspacing="0" cellpadding="0" {{ ctaFullWidthStyle | raw }}>
                             <tr>
-                                <td align="center" class="bsi-cta-wrapper" style="{{ borderCssOutlook }} border-radius: {{ ctaBorderRadius }}px; background-color: {{ ctaBackgroundColor }}; " {{ ctaFullWidthStyle | raw }}>
+                                <td align="center" class="bsi-cta-wrapper" style="{{ borderCssOutlook }} {{borderCss}} border-radius: {{ ctaBorderRadius }}px; background-color: {{ ctaBackgroundColor }}; " {{ ctaFullWidthStyle | raw }}>
                                     <!--[if mso]><div style="mso-line-height-rule: exactly; line-height: {{ctaVerticalPadding}}px; height: {{ctaVerticalPadding}}px; font-size: {{ctaVerticalPadding}}px">&nbsp;</div><![endif]-->
                                     {% if ctaFullWidth != true %}
                                         <!--[if mso]><b style="letter-spacing: {{ ctaHorizontalPadding }}px;mso-font-width:-100%;">&nbsp;</b><![endif]-->
                                     {% endif %}
                                 
-                                    <a href="https://example.org/" target="_blank" data-bsi-element-part="{{ ctaElementPartId }}" class="bsi-cta" style="mso-line-height-rule: exactly; font-size: {{ ctaFontSize }}px; line-height: {{ ctaFontSize }}px; font-family: {{ ctaFontFamily }}; color: {{ ctaTextColor }}; font-weight: {{ ctaFontWeight }}; text-decoration: none; {{ borderCss }} mso-border-alt: none; border-radius: {{ ctaBorderRadius }}px; padding: {{ ctaVerticalPadding }}px {{ ctaHorizontalPadding }}px; display: inline-block; text-align:center; word-break: keep-all;  mso-padding-alt: 0; text-underline-color: {{ ctaBackgroundColor }};" {{ ctaFullWidthStyle | raw }}>{{ bsi_cx_lorem(2)}}</a>
+                                    <a href="https://example.org/" target="_blank" data-bsi-element-part="{{ ctaElementPartId }}" class="bsi-cta" style="mso-line-height-rule: exactly; font-size: {{ ctaFontSize }}px; line-height: {{ ctaFontSize }}px; font-family: {{ ctaFontFamily }}; color: {{ ctaTextColor }}; font-weight: {{ ctaFontWeight }}; text-decoration: none; mso-border-alt: none; border-radius: {{ ctaBorderRadius }}px; padding: {{ ctaVerticalPadding }}px {{ ctaHorizontalPadding }}px; display: inline-block; text-align:center; word-break: keep-all;  mso-padding-alt: 0; text-underline-color: {{ ctaBackgroundColor }};" {{ ctaFullWidthStyle | raw }}>{{ bsi_cx_lorem(2)}}</a>
                                 
                                     {% if ctaFullWidth != true %}
                                         <!--[if mso]><b style="letter-spacing: {{ ctaHorizontalPadding }}px;mso-font-width:-100%;">&nbsp;</b><![endif]-->


### PR DESCRIPTION
Ich hatte beim inSign Template doch ein paar Variablen im cta.twig verändert gehabt. Das habe ich jetzt versucht zu vermeiden und das cta-layout so erweitert, dass es jetzt hoffentlich alles passt. 
Nur eine Sache musste ich im twig ergänzen, weil sonst das CX gemeckert hatte. Anscheinend mag es nicht, wenn ein Style, der bisher nicht existente ergänzt wird. Aber vielleicht gibt es da auch einen anderen Weg.